### PR TITLE
fixed gas limit param

### DIFF
--- a/src/cljs/status_dapp/components.cljs
+++ b/src/cljs/status_dapp/components.cljs
@@ -32,6 +32,6 @@
 
 (defn asset-button [label asset-address]
   [react/view {:style {:margin-bottom 10}}
-   [button (str "Request " label) #(re-frame/dispatch [:send-transaction {:to       asset-address
-                                                                          :value    0
-                                                                          :gasPrise 150000}])]])
+   [button (str "Request " label) #(re-frame/dispatch [:send-transaction {:to    asset-address
+                                                                          :value 0
+                                                                          :gas   150000}])]])


### PR DESCRIPTION
Fixes a typo `gasPrise` -> `gas` 
(I assume we want gas limit here)

request test assets currently doesn't work - probably has something to do with this and the other gas from dapps bug