### PR TITLE
Use promise resolve value instead of global var

### DIFF
--- a/src/cljs/status_dapp/db.cljs
+++ b/src/cljs/status_dapp/db.cljs
@@ -3,17 +3,12 @@
 
 (def dapp-store? (re-find #"#dapp-store" (-> js/window .-location .-href)))
 
-(def web3 (or dapp-store? (when (exists? js/web3) js/web3)
-              #_(when (exists? js/ethereumBeta)
-                  (js/setTimeout (fn []
-                                   (.then (.send js/ethereumBeta "eth_requestAccounts") #(re-frame/dispatch [:set-default-account]))
-                                   (when js/ethereumBeta
-                                     (.then (.getContactCode js/ethereumBeta.status) #(re-frame/dispatch [:on-status-api :contact %]))))
-                                 100)
-                  (js/Web3. js/ethereumBeta))
+(def web3 (or dapp-store? (when (exists? js/web3) 
+                            js/web3)
               (when (exists? js/ethereum)
                 (js/setTimeout (fn []
-                                 (.then (.enable js/ethereum) #(re-frame/dispatch [:set-default-account]))
+                                 (.then (.enable js/ethereum) 
+                                        #(re-frame/dispatch [:set-default-account (first %1)]))
                                  (when js/ethereum.status
                                    (.then (.getContactCode js/ethereum.status) #(re-frame/dispatch [:on-status-api :contact %]))))
                                100)

--- a/src/cljs/status_dapp/events.cljs
+++ b/src/cljs/status_dapp/events.cljs
@@ -292,6 +292,6 @@
 
 (re-frame/reg-event-fx
  :set-default-account
- (fn [{db :db} _]
-   (set! (.-defaultAccount (.-eth (:web3 db))) js/currentAccountAddress)
+ (fn [{db :db} [_ current-account-address]]
+   (set! (.-defaultAccount (.-eth (:web3 db))) current-account-address)
    {:dispatch [:request-web3-async-data]}))


### PR DESCRIPTION
`currentAccountAddress` is an ad-hoc variable we use in status-react's `provider.js`. It seems better to use promise's resolve value instead. We pass existing account addresses to promise callback [here](https://github.com/status-im/status-react/blob/1e44b433c5f3d55336efd8c76d677244d353ed26/resources/js/provider.js#L75) anyway, so no sense to have an additional global var.